### PR TITLE
Pin Rust toolchain to 1.94.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.94.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- Add `rust-toolchain.toml` pinning to Rust 1.94.0 with rustfmt and clippy components
- Prevents formatting drift between local dev and CI (local was on 1.85.1, CI on 1.94.0)

## Test plan
- [ ] CI passes with pinned toolchain
- [ ] `cargo fmt --check` produces no diff locally and in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)