### PR TITLE
Add `smuggle dev` command

### DIFF
--- a/src/dev.rs
+++ b/src/dev.rs
@@ -1,0 +1,254 @@
+use console::style;
+use std::path::Path;
+use std::process::{Child, Command};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::{install, pack, pm, store, watch};
+
+pub fn cmd_dev(
+    consumer_dir: &Path,
+    select_all: bool,
+    restart: bool,
+    command: &[String],
+) -> Result<(), String> {
+    let consumer_dir = consumer_dir
+        .canonicalize()
+        .map_err(|e| format!("invalid path: {e}"))?;
+
+    let pkg_json_path = consumer_dir.join("package.json");
+    if !pkg_json_path.exists() {
+        return Err("no package.json found in consumer directory".into());
+    }
+
+    let _ = cliclack::intro(style(" smuggle dev ").on_cyan().black());
+
+    // Resolve the dev command
+    let dev_cmd = resolve_dev_command(&consumer_dir, command)?;
+    let _ = cliclack::log::info(format!(
+        "Dev command: {}",
+        style(shell_join(&dev_cmd)).cyan()
+    ));
+
+    // Select packages (reuse install's matching logic)
+    let consumer_pkg: pack::ConsumerPackageJson =
+        serde_json::from_str(&std::fs::read_to_string(&pkg_json_path).map_err(|e| e.to_string())?)
+            .map_err(|e| format!("failed to parse consumer package.json: {e}"))?;
+
+    let all_deps = consumer_pkg.all_dependency_names();
+    let registered = store::list();
+    let mut matches: Vec<&store::StoreEntry> = registered
+        .iter()
+        .filter(|entry| all_deps.contains(&entry.name))
+        .collect();
+
+    if matches.is_empty() {
+        return Err(
+            "no registered packages found in consumer's dependencies. publish some first with `smuggle publish`."
+                .into(),
+        );
+    }
+
+    matches.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let selected: Vec<&store::StoreEntry> = if select_all {
+        let list: Vec<String> = matches
+            .iter()
+            .map(|e| {
+                format!(
+                    "{} @ {} ({})",
+                    style(&e.name).cyan(),
+                    e.version,
+                    e.source_dir.display()
+                )
+            })
+            .collect();
+        cliclack::log::info(format!(
+            "Selecting all {} matching package(s)\n{}",
+            matches.len(),
+            list.join("\n"),
+        ))
+        .map_err(|e| e.to_string())?;
+        matches.clone()
+    } else {
+        let mut prompt = cliclack::multiselect("Select packages to proxy locally");
+        for (i, e) in matches.iter().enumerate() {
+            let label = format!("{} @ {}", e.name, e.version);
+            let hint = e.source_dir.display().to_string();
+            prompt = prompt.item(i, label, hint);
+        }
+        let all_indices: Vec<usize> = (0..matches.len()).collect();
+        prompt = prompt.initial_values(all_indices);
+
+        let selections: Vec<usize> = prompt
+            .interact()
+            .map_err(|e| format!("selection cancelled: {e}"))?;
+        if selections.is_empty() {
+            let _ = cliclack::outro("No packages selected, nothing to do.");
+            return Ok(());
+        }
+        selections.iter().map(|&i| matches[i]).collect()
+    };
+
+    // Expand transitive deps
+    let all_entries = install::expand_with_registered_deps(&selected, &registered);
+    let all_refs: Vec<&store::StoreEntry> = all_entries.iter().collect();
+
+    if all_refs.len() > selected.len() {
+        let extra: Vec<&str> = all_refs
+            .iter()
+            .filter(|e| !selected.iter().any(|s| s.name == e.name))
+            .map(|e| e.name.as_str())
+            .collect();
+        cliclack::log::info(format!(
+            "Also proxying {} transitive dep(s): {}",
+            extra.len(),
+            extra
+                .iter()
+                .map(|n| style(n).cyan().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        ))
+        .map_err(|e| e.to_string())?;
+    }
+
+    // Resolve targets
+    let targets = install::resolve_targets(&all_refs, &consumer_dir, &[])?;
+    if targets.is_empty() {
+        return Err("none of the selected packages are installed in node_modules".into());
+    }
+
+    // Initial one-shot extraction (no backup)
+    let extract_spinner = cliclack::spinner();
+    extract_spinner.start(format!("Smuggling {} package(s)...", targets.len()));
+    for target in &targets {
+        let tarball = store::load_tarball(&target.name)?;
+        pack::extract_tarball_to(&tarball, &target.target_dir)?;
+    }
+    extract_spinner.stop(format!(
+        "Smuggled {} package(s) into node_modules",
+        style(targets.len()).green()
+    ));
+
+    // Spawn dev server
+    let child: Arc<Mutex<Option<Child>>> =
+        Arc::new(Mutex::new(Some(spawn_dev_server(&dev_cmd, &consumer_dir)?)));
+
+    // Set up ctrl-c handler
+    let should_exit = Arc::new(AtomicBool::new(false));
+    {
+        let should_exit = should_exit.clone();
+        let child = child.clone();
+        let _ = ctrlc::set_handler(move || {
+            should_exit.store(true, Ordering::SeqCst);
+            if let Ok(mut guard) = child.lock() {
+                if let Some(ref mut c) = *guard {
+                    let _ = c.kill();
+                    let _ = c.wait();
+                }
+            }
+        });
+    }
+
+    cliclack::log::success(format!(
+        "Watching for changes... {}",
+        style("(ctrl-c to stop)").dim()
+    ))
+    .map_err(|e| e.to_string())?;
+
+    if restart {
+        let child_for_swap = child.clone();
+        let dev_cmd_clone = dev_cmd.clone();
+        let consumer_dir_clone = consumer_dir.clone();
+
+        let mut action = watch::PostSwapAction::Notify {
+            on_swap: Box::new(move |changed: &[String]| {
+                let _ = cliclack::log::info(format!(
+                    "Restarting dev server (changed: {})...",
+                    changed.join(", ")
+                ));
+                if let Ok(mut guard) = child_for_swap.lock() {
+                    if let Some(ref mut c) = *guard {
+                        let _ = c.kill();
+                        let _ = c.wait();
+                    }
+                    match spawn_dev_server(&dev_cmd_clone, &consumer_dir_clone) {
+                        Ok(new_child) => *guard = Some(new_child),
+                        Err(e) => {
+                            let _ = cliclack::log::warning(format!(
+                                "Failed to restart dev server: {e}"
+                            ));
+                            *guard = None;
+                        }
+                    }
+                }
+            }),
+        };
+
+        watch::watch_and_reinstall_until(&all_refs, &targets, &mut action, &should_exit)?;
+    } else {
+        let mut action = watch::PostSwapAction::ClearCachesAndTouch {
+            consumer_dir: &consumer_dir,
+            workspace_pkg_dirs: &[],
+        };
+        watch::watch_and_reinstall_until(&all_refs, &targets, &mut action, &should_exit)?;
+    }
+
+    // Kill dev server on normal exit
+    if let Ok(mut guard) = child.lock() {
+        if let Some(ref mut c) = *guard {
+            let _ = c.kill();
+            let _ = c.wait();
+        }
+    }
+
+    let _ = cliclack::outro("Done");
+    Ok(())
+}
+
+fn resolve_dev_command(consumer_dir: &Path, explicit: &[String]) -> Result<Vec<String>, String> {
+    if !explicit.is_empty() {
+        return Ok(explicit.to_vec());
+    }
+
+    if pm::has_script(consumer_dir, "dev") {
+        let pm_name = pm::detect_package_manager(consumer_dir);
+        return Ok(vec![
+            pm_name.to_string(),
+            "run".to_string(),
+            "dev".to_string(),
+        ]);
+    }
+
+    Err(format!(
+        "no {} script found in package.json. Pass your dev command after {}: smuggle dev -- <command>",
+        style("dev").cyan(),
+        style("--").cyan(),
+    ))
+}
+
+fn spawn_dev_server(cmd: &[String], cwd: &Path) -> Result<Child, String> {
+    let (program, args) = cmd
+        .split_first()
+        .ok_or_else(|| "empty dev command".to_string())?;
+
+    Command::new(program)
+        .args(args)
+        .current_dir(cwd)
+        .spawn()
+        .map_err(|e| format!("failed to start `{}`: {e}", shell_join(cmd)))
+}
+
+fn shell_join(parts: &[String]) -> String {
+    parts
+        .iter()
+        .map(|s| {
+            if s.contains(' ') {
+                format!("\"{s}\"")
+            } else {
+                s.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}

--- a/src/install.rs
+++ b/src/install.rs
@@ -111,7 +111,14 @@ pub fn cmd_add(consumer_dir: &Path, name: &str, dev: bool, once: bool) -> Result
         target_dir,
     }];
     let entry_refs: Vec<&store::StoreEntry> = vec![entry];
-    watch::watch_and_reinstall(&entry_refs, &targets, &consumer_dir, &[])?;
+    watch::watch_and_reinstall(
+        &entry_refs,
+        &targets,
+        &mut watch::PostSwapAction::ClearCachesAndTouch {
+            consumer_dir: &consumer_dir,
+            workspace_pkg_dirs: &[],
+        },
+    )?;
 
     // Cleanup on normal exit
     let restore_spinner = cliclack::spinner();
@@ -429,7 +436,14 @@ fn run_install_flow(
     .map_err(|e| e.to_string())?;
 
     // Watch for changes
-    watch::watch_and_reinstall(&all_refs, &targets, install_dir, workspace_pkg_dirs)?;
+    watch::watch_and_reinstall(
+        &all_refs,
+        &targets,
+        &mut watch::PostSwapAction::ClearCachesAndTouch {
+            consumer_dir: install_dir,
+            workspace_pkg_dirs,
+        },
+    )?;
 
     // Cleanup on normal exit — restore originals
     let restore_spinner = cliclack::spinner();
@@ -443,7 +457,7 @@ fn run_install_flow(
 }
 
 /// Resolve each package to its real location in node_modules.
-fn resolve_targets(
+pub fn resolve_targets(
     entries: &[&store::StoreEntry],
     install_dir: &Path,
     workspace_pkg_dirs: &[PathBuf],
@@ -574,7 +588,7 @@ fn extract_all(targets: &[watch::OverrideTarget]) -> Result<(), String> {
 
 /// Expand the selected set to include any registered packages that are
 /// transitive dependencies of the selected packages.
-fn expand_with_registered_deps(
+pub fn expand_with_registered_deps(
     selected: &[&store::StoreEntry],
     registered: &[store::StoreEntry],
 ) -> Vec<store::StoreEntry> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::collapsible_if)]
 
 mod backup;
+mod dev;
 mod install;
 mod pack;
 mod pm;
@@ -89,6 +90,25 @@ enum Commands {
         #[arg(long)]
         once: bool,
     },
+
+    /// Swap local packages and run your dev server
+    Dev {
+        /// Path to the consumer project (defaults to current directory)
+        #[arg(short, long)]
+        path: Option<PathBuf>,
+
+        /// Select all matching packages without prompting
+        #[arg(long)]
+        all: bool,
+
+        /// Kill and restart the dev server on each package change (instead of relying on HMR)
+        #[arg(long)]
+        restart: bool,
+
+        /// Dev server command (auto-detected from package.json "dev" script if omitted)
+        #[arg(last = true)]
+        command: Vec<String>,
+    },
 }
 
 fn main() {
@@ -118,6 +138,21 @@ fn main() {
             let all = all || cli.all;
             let once = once || cli.once;
             if let Err(e) = install::cmd_install(&consumer_dir, all, once) {
+                let _ = cliclack::outro(format!("{}", style(e).red()));
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Dev {
+            path,
+            all,
+            restart,
+            command,
+        }) => {
+            let consumer_dir = path
+                .or(cli.path)
+                .unwrap_or_else(|| std::env::current_dir().unwrap());
+            let all = all || cli.all;
+            if let Err(e) = dev::cmd_dev(&consumer_dir, all, restart, &command) {
                 let _ = cliclack::outro(format!("{}", style(e).red()));
                 std::process::exit(1);
             }

--- a/src/pm.rs
+++ b/src/pm.rs
@@ -72,6 +72,36 @@ pub fn clear_bundler_caches(root: &Path, extra_dirs: &[&Path]) {
     }
 }
 
+/// Detect which package manager is used in the given directory.
+/// Checks for lockfiles in order: pnpm, yarn, bun, npm (fallback).
+pub fn detect_package_manager(dir: &Path) -> &'static str {
+    if dir.join("pnpm-lock.yaml").exists() {
+        "pnpm"
+    } else if dir.join("yarn.lock").exists() {
+        "yarn"
+    } else if dir.join("bun.lockb").exists() || dir.join("bun.lock").exists() {
+        "bun"
+    } else {
+        "npm"
+    }
+}
+
+/// Check if a package.json in the given directory has a specific script.
+pub fn has_script(dir: &Path, script: &str) -> bool {
+    let pkg_json_path = dir.join("package.json");
+    let Ok(raw) = std::fs::read_to_string(pkg_json_path) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return false;
+    };
+    value
+        .get("scripts")
+        .and_then(|s| s.get(script))
+        .and_then(|v| v.as_str())
+        .is_some()
+}
+
 /// Touch the vite config file (if any) to trigger a dev server restart.
 /// Checks root and all workspace member directories.
 pub fn touch_vite_configs(root: &Path, workspace_pkg_dirs: &[PathBuf]) {

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,5 +1,7 @@
 use console::style;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::{backup, pack, pm, store};
 
@@ -9,12 +11,46 @@ pub struct OverrideTarget {
     pub target_dir: PathBuf,
 }
 
+/// What to do after successfully swapping packages in node_modules.
+pub enum PostSwapAction<'a> {
+    /// Clear bundler caches and touch vite configs to trigger HMR reload.
+    ClearCachesAndTouch {
+        consumer_dir: &'a Path,
+        workspace_pkg_dirs: &'a [PathBuf],
+    },
+    /// Call a function after each swap (e.g. to restart a dev server).
+    #[allow(clippy::type_complexity)]
+    Notify {
+        /// Called after each successful swap with the list of changed package names.
+        on_swap: Box<dyn FnMut(&[String]) + 'a>,
+    },
+}
+
 /// Watch source directories for changes and re-extract tarballs when content changes.
+/// If `shutdown` is provided, the loop exits when the flag is set.
 pub fn watch_and_reinstall(
     selected: &[&store::StoreEntry],
     targets: &[OverrideTarget],
-    consumer_dir: &Path,
-    workspace_pkg_dirs: &[PathBuf],
+    action: &mut PostSwapAction<'_>,
+) -> Result<(), String> {
+    watch_and_reinstall_inner(selected, targets, action, None)
+}
+
+/// Like `watch_and_reinstall`, but exits when `shutdown` is set to true.
+pub fn watch_and_reinstall_until(
+    selected: &[&store::StoreEntry],
+    targets: &[OverrideTarget],
+    action: &mut PostSwapAction<'_>,
+    shutdown: &Arc<AtomicBool>,
+) -> Result<(), String> {
+    watch_and_reinstall_inner(selected, targets, action, Some(shutdown))
+}
+
+fn watch_and_reinstall_inner(
+    selected: &[&store::StoreEntry],
+    targets: &[OverrideTarget],
+    action: &mut PostSwapAction<'_>,
+    shutdown: Option<&Arc<AtomicBool>>,
 ) -> Result<(), String> {
     use notify::{RecursiveMode, Watcher};
     use std::collections::HashMap;
@@ -64,9 +100,28 @@ pub fn watch_and_reinstall(
     let batch_window = Duration::from_secs(5);
     let stabilize_delay = Duration::from_secs(1);
 
+    let poll_interval = Duration::from_millis(200);
+
     loop {
-        let Ok(first_event) = rx.recv() else {
-            break;
+        // Check shutdown flag before blocking
+        if let Some(flag) = shutdown {
+            if flag.load(Ordering::SeqCst) {
+                break;
+            }
+        }
+
+        // Use recv_timeout so we can check the shutdown flag periodically
+        let first_event = if shutdown.is_some() {
+            match rx.recv_timeout(poll_interval) {
+                Ok(event) => event,
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        } else {
+            match rx.recv() {
+                Ok(event) => event,
+                Err(_) => break,
+            }
         };
 
         let batch_start = Instant::now();
@@ -162,31 +217,35 @@ pub fn watch_and_reinstall(
             }
         }
 
-        // Transactional extraction: backup, extract all, rollback on failure
+        // Extract changed packages into node_modules
         let mut actually_changed: Vec<String> = Vec::new();
         if !to_extract.is_empty() {
-            let backup_pairs: Vec<(String, PathBuf)> = to_extract
-                .iter()
-                .map(|(name, _, target)| (name.clone(), target.clone()))
-                .collect();
+            let use_backup = matches!(action, PostSwapAction::ClearCachesAndTouch { .. });
 
-            let backup_base = match backup::backup_targets(&backup_pairs) {
-                Ok(b) => b,
-                Err(e) => {
-                    spinner.stop(format!("{} backup failed: {e}", style("✗").red()));
-                    continue;
+            let backup_state = if use_backup {
+                let backup_pairs: Vec<(String, PathBuf)> = to_extract
+                    .iter()
+                    .map(|(name, _, target)| (name.clone(), target.clone()))
+                    .collect();
+                match backup::backup_targets(&backup_pairs) {
+                    Ok(base) => Some((base, backup_pairs)),
+                    Err(e) => {
+                        spinner.stop(format!("{} backup failed: {e}", style("✗").red()));
+                        continue;
+                    }
                 }
+            } else {
+                None
             };
 
             spinner.start(format!("Smuggling {} package(s)...", to_extract.len()));
             let mut failed = false;
             for (pkg_name, tarball, target_dir) in &to_extract {
                 if let Err(e) = pack::extract_tarball_to(tarball, target_dir) {
-                    spinner.stop(format!(
-                        "{} extraction failed: {e} — rolling back",
-                        style("✗").red()
-                    ));
-                    backup::restore_all(&backup_base, &backup_pairs);
+                    spinner.stop(format!("{} extraction failed: {e}", style("✗").red()));
+                    if let Some((ref base, ref pairs)) = backup_state {
+                        backup::restore_all(base, pairs);
+                    }
                     failed = true;
                     break;
                 }
@@ -194,8 +253,9 @@ pub fn watch_and_reinstall(
             }
 
             if !failed {
-                // Extraction succeeded, remove backup
-                let _ = std::fs::remove_dir_all(&backup_base);
+                if let Some((ref base, _)) = backup_state {
+                    let _ = std::fs::remove_dir_all(base);
+                }
             } else {
                 actually_changed.clear();
             }
@@ -206,15 +266,25 @@ pub fn watch_and_reinstall(
             continue;
         }
 
-        // Clear bundler caches and trigger vite restart
-        let extra: Vec<&Path> = workspace_pkg_dirs.iter().map(|p| p.as_path()).collect();
-        pm::clear_bundler_caches(consumer_dir, &extra);
-        pm::touch_vite_configs(consumer_dir, workspace_pkg_dirs);
-
         spinner.stop(format!(
             "Smuggled {}",
             style(actually_changed.join(", ")).cyan()
         ));
+
+        // Post-swap action
+        match action {
+            PostSwapAction::ClearCachesAndTouch {
+                consumer_dir,
+                workspace_pkg_dirs,
+            } => {
+                let extra: Vec<&Path> = workspace_pkg_dirs.iter().map(|p| p.as_path()).collect();
+                pm::clear_bundler_caches(consumer_dir, &extra);
+                pm::touch_vite_configs(consumer_dir, workspace_pkg_dirs);
+            }
+            PostSwapAction::Notify { on_swap } => {
+                on_swap(&actually_changed);
+            }
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Adds `smuggle dev` subcommand that swaps local packages into node_modules and spawns the user's dev server
- Auto-detects dev command from `package.json` scripts + package manager lockfiles, or accepts explicit command via `smuggle dev -- <cmd>`
- `--restart` flag opts into killing and respawning the dev server on each package change; default relies on HMR
- Refactors watch loop to support pluggable post-swap actions (`ClearCachesAndTouch` for HMR, `Notify` callback for restart)

## Usage
```
smuggle dev                          # auto-detect: pnpm/npm/yarn/bun run dev
smuggle dev -- next dev --port 3001  # explicit command
smuggle dev --restart                # kill+respawn on change
smuggle dev --all --restart          # skip selection prompt
```

## Test plan
- [x] All 52 existing tests pass
- [ ] Manual test: `smuggle dev` with a vite project (HMR path)
- [ ] Manual test: `smuggle dev --restart` with a non-HMR project
- [ ] Manual test: `smuggle dev -- <custom command>`
- [ ] Manual test: auto-detection with npm, pnpm, yarn lockfiles
- [ ] Verify ctrl-c cleanly kills the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)