### PR TITLE
Add a terminal UI

### DIFF
--- a/.changeset/brave-lions-watch.md
+++ b/.changeset/brave-lions-watch.md
@@ -1,0 +1,9 @@
+---
+"smuggle-cli": minor
+---
+
+Adds `smuggle ui`, a terminal interface for driving a session.
+
+It opens with nothing hijacked and lists everything you have published. Press space on a package to start serving your local build of it, and space again to stop; smuggle re-pins your lockfile and reinstalls each time, so you can swap a dependency in and out without restarting anything. Quitting ends the session and puts the published packages back.
+
+Alongside the session view there is a store view for evicting or repacking what you have published, and a doctor view that checks your certificate authority, the background daemon, the `/etc/hosts` redirect, and which registry this project actually resolves through. The doctor's worst result is shown in the header from every view, so a stale daemon or a registry smuggle is not intercepting is visible immediately rather than looking like nothing happening.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +78,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -168,9 +183,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -208,10 +223,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -296,6 +326,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +370,15 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -371,6 +424,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.1",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +468,40 @@ dependencies = [
  "dispatch2",
  "nix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -417,6 +531,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,7 +575,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -455,6 +591,21 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -525,6 +676,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fsevent-sys"
@@ -610,7 +767,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -618,6 +775,22 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -743,6 +916,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "ignore"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,12 +963,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
@@ -804,10 +992,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -823,6 +1033,17 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror",
 ]
 
 [[package]]
@@ -864,15 +1085,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -882,10 +1118,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "memchr"
@@ -927,7 +1187,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -955,7 +1215,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -973,7 +1233,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1011,6 +1271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1314,62 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "libm",
+ "palette_derive",
+ "palette_math",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pem"
@@ -1145,6 +1470,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.1",
+ "compact_str",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.1",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,11 +1551,20 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1211,6 +1611,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,7 +1634,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1282,6 +1691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,6 +1704,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1368,6 +1789,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1857,7 @@ dependencies = [
  "libc",
  "notify",
  "predicates",
+ "ratatui",
  "rcgen",
  "rustls",
  "rustls-pemfile",
@@ -1442,10 +1885,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -1554,7 +2024,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -1661,6 +2133,23 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "unicode-width"
@@ -1817,7 +2306,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1843,6 +2332,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,6 +2355,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2080,7 +2591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,13 @@ rcgen = { version = "0.14.9", features = ["pem", "x509-parser"] }
 rustls-pemfile = "2.2.0"
 libc = "0.2.189"
 webpki-roots = "1.0.9"
-time = { version = "0.3.55", default-features = false, features = ["std"] }
+time = { version = "0.3.55", default-features = false, features = ["formatting", "local-offset", "std"] }
 hyper-rustls = { version = "0.27.9", default-features = false, features = ["http1", "ring", "webpki-tokio", "tls12"] }
 tower-service = "0.3.3"
 sha2 = "0.11.0"
 sha1 = "0.11.0"
 base64 = "0.23.1"
+ratatui = { version = "0.30.2", default-features = false, features = ["crossterm"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -210,6 +210,22 @@ fn replace_integrity(line: &str, hash: &str) -> Option<String> {
 pub struct Pin {
     session: PathBuf,
     lockfile: PathBuf,
+    kind: Kind,
+    /// The lockfile exactly as it was found. Every rewrite starts from this
+    /// rather than from the current file, so removing a package restores its
+    /// original integrity instead of leaving the last pin in place.
+    original: String,
+}
+
+impl Pin {
+    /// Re-pin for a different set of packages. Returns how many entries are
+    /// pinned, which is zero when nothing is hijacked any more.
+    pub fn set(&self, hashes: &HashMap<String, String>) -> Result<usize, String> {
+        let (rewritten, changed) = rewrite(self.kind, &self.original, hashes)?;
+        std::fs::write(&self.lockfile, rewritten)
+            .map_err(|e| format!("could not write {}: {e}", self.lockfile.display()))?;
+        Ok(changed)
+    }
 }
 
 impl Drop for Pin {
@@ -231,14 +247,23 @@ fn session_id(lockfile: &Path) -> String {
     format!("{:016x}", hasher.finish())
 }
 
-/// Back up the lockfile and rewrite it to point at the tarballs we serve.
-pub fn pin(lockfile: &Lockfile, hashes: &HashMap<String, String>) -> Result<Pin, String> {
+/// Back up the lockfile so it can be rewritten and restored.
+///
+/// `require_match` rejects a pin that would change nothing, which is what a
+/// command-line session wants: it was asked for specific packages and none of
+/// them are in this project. A UI that starts with nothing hijacked pins
+/// lazily instead, so it passes false.
+pub fn pin(
+    lockfile: &Lockfile,
+    hashes: &HashMap<String, String>,
+    require_match: bool,
+) -> Result<Pin, String> {
     let original = std::fs::read_to_string(&lockfile.path)
         .map_err(|e| format!("could not read {}: {e}", lockfile.path.display()))?;
 
     let (rewritten, changed) = rewrite(lockfile.kind, &original, hashes)?;
 
-    if changed == 0 {
+    if require_match && changed == 0 {
         return Err(format!(
             "none of the selected packages appear in {}. Are they dependencies of this project?",
             lockfile.path.display()
@@ -263,23 +288,27 @@ pub fn pin(lockfile: &Lockfile, hashes: &HashMap<String, String>) -> Result<Pin,
     std::fs::write(&lockfile.path, rewritten)
         .map_err(|e| format!("could not write {}: {e}", lockfile.path.display()))?;
 
-    let _ = cliclack::log::info(format!(
-        "Pinned {} entr{} in {} to your local build",
-        style(changed).cyan(),
-        if changed == 1 { "y" } else { "ies" },
-        style(
-            lockfile
-                .path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-        )
-        .dim(),
-    ));
+    if changed > 0 {
+        let _ = cliclack::log::info(format!(
+            "Pinned {} entr{} in {} to your local build",
+            style(changed).cyan(),
+            if changed == 1 { "y" } else { "ies" },
+            style(
+                lockfile
+                    .path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+            )
+            .dim(),
+        ));
+    }
 
     Ok(Pin {
         session,
         lockfile: lockfile.path.clone(),
+        kind: lockfile.kind,
+        original,
     })
 }
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -359,7 +359,8 @@ pub fn reconcile() {
     }
 }
 
-/// Run the consumer's package manager so the pin takes effect.
+/// Run the consumer's package manager so the pin takes effect, letting its
+/// output through to the terminal.
 pub fn install(consumer_dir: &Path, kind: Kind) -> Result<(), String> {
     let (program, args) = kind.command();
 
@@ -368,13 +369,7 @@ pub fn install(consumer_dir: &Path, kind: Kind) -> Result<(), String> {
         style(format!("{program} {}", args.join(" "))).cyan()
     ));
 
-    // Node ignores the macOS keychain, so the package manager has to be told
-    // about our CA. Setting it here rather than relying on the shell profile
-    // means setup takes effect immediately, with no terminal restart.
-    let status = std::process::Command::new(program)
-        .args(args)
-        .current_dir(consumer_dir)
-        .env("NODE_EXTRA_CA_CERTS", ca::cert_path())
+    let status = command(consumer_dir, kind)
         .status()
         .map_err(|e| format!("failed to run `{program}`: {e}"))?;
 
@@ -382,6 +377,46 @@ pub fn install(consumer_dir: &Path, kind: Kind) -> Result<(), String> {
         return Err(format!("`{program} {}` failed", args.join(" ")));
     }
     Ok(())
+}
+
+/// As [`install`], but capturing the package manager's output instead of
+/// letting it reach the terminal, and returning it line by line.
+///
+/// A UI owns the screen: anything the package manager printed itself would be
+/// drawn over the frame and corrupt it.
+pub fn install_captured(consumer_dir: &Path, kind: Kind) -> Result<Vec<String>, String> {
+    let (program, args) = kind.command();
+
+    let output = command(consumer_dir, kind)
+        .output()
+        .map_err(|e| format!("failed to run `{program}`: {e}"))?;
+
+    let lines: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .chain(String::from_utf8_lossy(&output.stderr).lines())
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect();
+
+    if !output.status.success() {
+        let reason = lines.last().cloned().unwrap_or_default();
+        return Err(format!("`{program} {}` failed: {reason}", args.join(" ")));
+    }
+    Ok(lines)
+}
+
+fn command(consumer_dir: &Path, kind: Kind) -> std::process::Command {
+    let (program, args) = kind.command();
+    let mut command = std::process::Command::new(program);
+    command
+        .args(args)
+        .current_dir(consumer_dir)
+        // Node ignores the macOS keychain, so the package manager has to be
+        // told about our CA. Setting it here rather than relying on the shell
+        // profile means setup takes effect immediately, with no restart.
+        .env("NODE_EXTRA_CA_CERTS", ca::cert_path());
+    command
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod publish;
 mod session;
 mod setup;
 mod store;
+mod tui;
 mod watch;
 mod workspace;
 
@@ -76,6 +77,13 @@ enum Commands {
         /// Skip interactive prompts and select all matching packages
         #[arg(long)]
         all: bool,
+    },
+
+    /// Open the terminal UI: pick packages to hijack, watch activity, check setup
+    Ui {
+        /// Path to the consumer project (defaults to current directory)
+        #[arg(short, long)]
+        path: Option<PathBuf>,
     },
 
     /// List all registered local packages (non-blocking)
@@ -179,6 +187,9 @@ fn main() {
             &cli.registries,
             cli.verbose,
         ),
+        Some(Commands::Ui { path }) => {
+            tui::run(&path.or(cli.path).unwrap_or_else(cwd), &cli.registries)
+        }
         Some(Commands::List) => {
             cmd_list();
             Ok(())

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,7 +23,25 @@ use crate::{lockfile, pack, store, watch};
 /// A registration with the daemon. Dropping it closes the connection, which
 /// is how the daemon learns the session is over and takes the redirect down.
 pub struct Registration {
-    _stream: UnixStream,
+    stream: UnixStream,
+    registries: Vec<String>,
+}
+
+impl Registration {
+    /// Change what this session hijacks, without dropping the connection.
+    /// Reconnecting would leave the daemon briefly with no sessions, which
+    /// would tear the proxy down and rebuild it on every change.
+    pub fn set_packages(&mut self, packages: &[String]) -> Result<(), String> {
+        let request = serde_json::to_string(&control::Request::Register {
+            version: control::version(),
+            packages: packages.to_vec(),
+            registries: self.registries.clone(),
+            verbose: false,
+        })
+        .map_err(|e| format!("could not encode the request: {e}"))?;
+
+        writeln!(&self.stream, "{request}").map_err(|e| format!("could not reach the daemon: {e}"))
+    }
 }
 
 /// Register with the daemon so it hijacks `packages` for as long as we live.
@@ -116,7 +134,10 @@ pub fn start_with_sink(
         }
     });
 
-    Ok(Registration { _stream: stream })
+    Ok(Registration {
+        stream,
+        registries: registries.to_vec(),
+    })
 }
 
 /// Ask npm which registries this project actually resolves through.

--- a/src/session.rs
+++ b/src/session.rs
@@ -32,6 +32,19 @@ pub fn start(
     registries: &[String],
     verbose: bool,
 ) -> Result<Registration, String> {
+    start_with_sink(packages, registries, verbose, None)
+}
+
+/// As [`start`], but delivering replies to `sink` instead of stdout.
+///
+/// Events reach the connection that registered, so a UI has to read them here
+/// rather than opening a second connection, which would receive nothing.
+pub fn start_with_sink(
+    packages: &[String],
+    registries: &[String],
+    verbose: bool,
+    sink: Option<std::sync::mpsc::Sender<control::Reply>>,
+) -> Result<Registration, String> {
     let path = control::socket_path();
     let stream = UnixStream::connect(&path).map_err(|e| {
         if !crate::net::launchd::is_installed() {
@@ -84,10 +97,21 @@ pub fn start(
 
     std::thread::spawn(move || {
         for line in reader.lines().map_while(Result::ok) {
-            match serde_json::from_str::<control::Reply>(&line) {
-                Ok(control::Reply::Event { event }) => println!("{}", event.to_line()),
-                Ok(control::Reply::Log { line }) => println!("{line}"),
-                _ => {}
+            let Ok(reply) = serde_json::from_str::<control::Reply>(&line) else {
+                continue;
+            };
+            match &sink {
+                // A UI renders replies itself; printing here would corrupt it.
+                Some(sink) => {
+                    if sink.send(reply).is_err() {
+                        break;
+                    }
+                }
+                None => match reply {
+                    control::Reply::Event { event } => println!("{}", event.to_line()),
+                    control::Reply::Log { line } => println!("{line}"),
+                    _ => {}
+                },
             }
         }
     });
@@ -163,7 +187,7 @@ pub fn run(
 
     // The pin is only satisfiable while the proxy runs, so it is undone during
     // teardown below, before interception stops.
-    let pin = lockfile::pin(&lock, &tarball_hashes(&names))?;
+    let pin = lockfile::pin(&lock, &tarball_hashes(&names), true)?;
     lockfile::install(&consumer_dir, lock.kind)?;
 
     let _ = cliclack::log::info(format!(
@@ -233,7 +257,7 @@ fn teardown(
 /// The daemon tears the redirect down asynchronously once we deregister, so
 /// give it a moment before reinstalling. Returns false if it is still up,
 /// which is legitimate when another session holds it.
-fn wait_for_interception_to_stop() -> bool {
+pub fn wait_for_interception_to_stop() -> bool {
     for _ in 0..30 {
         if crate::net::hosts::read_block().is_none() {
             return true;
@@ -278,6 +302,16 @@ fn resolve_registries(consumer_dir: &Path, extra: &[String]) -> Vec<String> {
         }
     }
 
+    merge_registries(detected, extra)
+}
+
+/// As [`resolve_registries`], but printing nothing. A UI owns the terminal, so
+/// stray log lines would corrupt the frame.
+pub fn resolve_registries_quietly(consumer_dir: &Path, extra: &[String]) -> Vec<String> {
+    merge_registries(detect_registries(consumer_dir), extra)
+}
+
+fn merge_registries(detected: Vec<String>, extra: &[String]) -> Vec<String> {
     let mut all = detected;
     all.extend(extra.iter().cloned());
     all.extend(crate::net::DEFAULT_REGISTRIES.iter().map(|r| r.to_string()));

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -19,6 +19,9 @@ use super::store_view::{self, StoreItem};
 /// growing without bound over a long session.
 const ACTIVITY_LIMIT: usize = 500;
 
+/// More than any panel is tall, and far less than the backlog.
+const VISIBLE_ACTIVITY: usize = 100;
+
 #[derive(Clone, Copy, PartialEq)]
 pub enum View {
     Session,
@@ -39,8 +42,10 @@ impl View {
 /// Work that must not block the event loop.
 pub enum Work {
     /// The registration changed; re-pin and reinstall.
-    Applied(Result<String, String>),
+    Applied(Result<Vec<String>, String>),
     Repacked(Result<String, String>),
+    /// A fresh diagnostics report, built off the event loop.
+    Doctor(Box<doctor::Report>),
 }
 
 pub struct App {
@@ -72,9 +77,8 @@ impl App {
         pin: lockfile::Pin,
     ) -> Self {
         let (work_tx, work_rx) = channel();
-        let report = doctor::run(&consumer_dir, None);
 
-        Self {
+        let app = Self {
             consumer_dir,
             view: View::Session,
             selected: 0,
@@ -82,7 +86,7 @@ impl App {
             hijacked: HashSet::new(),
             activity: VecDeque::new(),
             status: None,
-            report,
+            report: doctor::Report::pending(),
             busy: None,
             error: None,
             should_quit: false,
@@ -91,7 +95,21 @@ impl App {
             lock,
             work_tx,
             work_rx,
-        }
+        };
+        app.refresh_report();
+        app
+    }
+
+    /// Rebuild diagnostics on a worker thread. Every check shells out, so
+    /// doing this inline would stall the frame for hundreds of milliseconds.
+    pub fn refresh_report(&self) {
+        let dir = self.consumer_dir.clone();
+        let status = self.status.clone();
+        let tx = self.work_tx.clone();
+        std::thread::spawn(move || {
+            let report = doctor::run(&dir, status.as_ref());
+            let _ = tx.send(Work::Doctor(Box::new(report)));
+        });
     }
 
     /// The data the UI draws from, with the live handles left behind.
@@ -102,7 +120,14 @@ impl App {
             selected: self.selected,
             items: &self.items,
             hijacked: &self.hijacked,
-            activity: self.activity.iter().cloned().collect(),
+            // Only what a panel could show. Cloning the whole backlog every
+            // frame would copy hundreds of strings several times a second.
+            activity: self
+                .activity
+                .iter()
+                .take(VISIBLE_ACTIVITY)
+                .cloned()
+                .collect(),
             registries: self
                 .status
                 .as_ref()
@@ -144,10 +169,9 @@ impl App {
             }
             Reply::Log { line } => self.push_activity(line),
             Reply::Error { message } => self.error = Some(message),
-            Reply::Status { status } => {
-                self.report = doctor::run(&self.consumer_dir, Some(&status));
-                self.status = Some(status);
-            }
+            // Status arrives on a timer. Rebuilding diagnostics here would
+            // shell out to npm, launchctl and security twice a second.
+            Reply::Status { status } => self.status = Some(status),
             Reply::Ok => {}
         }
     }
@@ -203,10 +227,7 @@ impl App {
         let kind = self.lock.kind;
         let tx = self.work_tx.clone();
         std::thread::spawn(move || {
-            let result = lockfile::install(&dir, kind)
-                .map(|()| "install finished".to_string())
-                .map_err(|e| e.to_string());
-            let _ = tx.send(Work::Applied(result));
+            let _ = tx.send(Work::Applied(lockfile::install_captured(&dir, kind)));
         });
     }
 
@@ -258,9 +279,29 @@ impl App {
     }
 
     pub fn on_work(&mut self, work: Work) {
-        self.busy = None;
+        // Diagnostics arrive independently of whatever the user asked for, so
+        // they must not clear a running install's indicator.
+        if !matches!(work, Work::Doctor(_)) {
+            self.busy = None;
+        }
+
         match work {
-            Work::Applied(Ok(line)) => self.push_activity(line),
+            Work::Doctor(report) => self.report = *report,
+            Work::Applied(Ok(output)) => {
+                // The package manager's own output would corrupt the frame if
+                // it reached the terminal, so it is folded into the feed.
+                let summary = output
+                    .iter()
+                    .rev()
+                    .find(|l| {
+                        l.contains("packages in")
+                            || l.contains("up to date")
+                            || l.starts_with("Done in")
+                    })
+                    .cloned()
+                    .unwrap_or_else(|| "install finished".to_string());
+                self.push_activity(summary);
+            }
             Work::Repacked(Ok(name)) => {
                 self.items = store_view::load();
                 self.push_activity(format!("repacked {name}"));
@@ -275,7 +316,7 @@ impl App {
 
     pub fn refresh(&mut self) {
         self.items = store_view::load();
-        self.report = doctor::run(&self.consumer_dir, self.status.as_ref());
+        self.refresh_report();
     }
 
     /// End the session the way ctrl-c does: unpin, stop interception, and put

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,0 +1,321 @@
+//! Application state.
+//!
+//! The UI owns the session: nothing is hijacked until you pick it, and quitting
+//! ends the session exactly as ctrl-c does, restoring the lockfile and putting
+//! the real packages back.
+
+use std::collections::{HashSet, VecDeque};
+use std::path::PathBuf;
+use std::sync::mpsc::{Receiver, Sender, channel};
+
+use crate::net::control::{DaemonStatus, Event, Reply};
+use crate::net::hijack;
+use crate::{lockfile, session, store};
+
+use super::doctor;
+use super::store_view::{self, StoreItem};
+
+/// How many activity lines to keep. Enough to see what an install did without
+/// growing without bound over a long session.
+const ACTIVITY_LIMIT: usize = 500;
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum View {
+    Session,
+    Store,
+    Doctor,
+}
+
+impl View {
+    pub fn title(self) -> &'static str {
+        match self {
+            View::Session => "session",
+            View::Store => "store",
+            View::Doctor => "doctor",
+        }
+    }
+}
+
+/// Work that must not block the event loop.
+pub enum Work {
+    /// The registration changed; re-pin and reinstall.
+    Applied(Result<String, String>),
+    Repacked(Result<String, String>),
+}
+
+pub struct App {
+    pub consumer_dir: PathBuf,
+    pub view: View,
+    pub selected: usize,
+    pub items: Vec<StoreItem>,
+    /// Packages currently hijacked. Empty until the user picks something.
+    pub hijacked: HashSet<String>,
+    pub activity: VecDeque<String>,
+    pub status: Option<DaemonStatus>,
+    pub report: doctor::Report,
+    pub busy: Option<String>,
+    pub error: Option<String>,
+    pub should_quit: bool,
+
+    registration: session::Registration,
+    pin: Option<lockfile::Pin>,
+    lock: lockfile::Lockfile,
+    work_tx: Sender<Work>,
+    pub work_rx: Receiver<Work>,
+}
+
+impl App {
+    pub fn new(
+        consumer_dir: PathBuf,
+        registration: session::Registration,
+        lock: lockfile::Lockfile,
+        pin: lockfile::Pin,
+    ) -> Self {
+        let (work_tx, work_rx) = channel();
+        let report = doctor::run(&consumer_dir, None);
+
+        Self {
+            consumer_dir,
+            view: View::Session,
+            selected: 0,
+            items: store_view::load(),
+            hijacked: HashSet::new(),
+            activity: VecDeque::new(),
+            status: None,
+            report,
+            busy: None,
+            error: None,
+            should_quit: false,
+            registration,
+            pin: Some(pin),
+            lock,
+            work_tx,
+            work_rx,
+        }
+    }
+
+    /// The data the UI draws from, with the live handles left behind.
+    pub fn snapshot(&self) -> super::view::Snapshot<'_> {
+        super::view::Snapshot {
+            consumer_dir: self.consumer_dir.display().to_string(),
+            view: self.view,
+            selected: self.selected,
+            items: &self.items,
+            hijacked: &self.hijacked,
+            activity: self.activity.iter().cloned().collect(),
+            registries: self
+                .status
+                .as_ref()
+                .map(|s| s.registries.join(", "))
+                .filter(|r| !r.is_empty()),
+            report: &self.report,
+            busy: self.busy.clone(),
+            error: self.error.clone(),
+        }
+    }
+
+    pub fn selected_item(&self) -> Option<&StoreItem> {
+        self.items.get(self.selected)
+    }
+
+    pub fn move_selection(&mut self, delta: isize) {
+        if self.items.is_empty() {
+            return;
+        }
+        let last = self.items.len() - 1;
+        self.selected = match delta {
+            d if d < 0 => self.selected.saturating_sub(d.unsigned_abs()),
+            d => (self.selected + d as usize).min(last),
+        };
+    }
+
+    pub fn push_activity(&mut self, line: String) {
+        self.activity.push_front(format!("{}  {line}", clock()));
+        self.activity.truncate(ACTIVITY_LIMIT);
+    }
+
+    pub fn on_reply(&mut self, reply: Reply) {
+        match reply {
+            Reply::Event { event } => {
+                if let Event::Error { message } = &event {
+                    self.error = Some(message.clone());
+                }
+                self.push_activity(event.to_line());
+            }
+            Reply::Log { line } => self.push_activity(line),
+            Reply::Error { message } => self.error = Some(message),
+            Reply::Status { status } => {
+                self.report = doctor::run(&self.consumer_dir, Some(&status));
+                self.status = Some(status);
+            }
+            Reply::Ok => {}
+        }
+    }
+
+    /// Toggle whether the selected package is hijacked, then apply the change.
+    pub fn toggle_selected(&mut self) {
+        if self.busy.is_some() {
+            return;
+        }
+        let Some(item) = self.selected_item() else {
+            return;
+        };
+        let name = item.entry.name.clone();
+
+        if !self.hijacked.remove(&name) {
+            self.hijacked.insert(name.clone());
+        }
+        self.apply(format!("applying {name}"));
+    }
+
+    /// Push the current set to the daemon, re-pin the lockfile, and reinstall.
+    /// The install runs off the event loop so the UI keeps drawing.
+    fn apply(&mut self, label: String) {
+        let packages: Vec<String> = {
+            let mut v: Vec<String> = self.hijacked.iter().cloned().collect();
+            v.sort();
+            v
+        };
+
+        if let Err(e) = self.registration.set_packages(&packages) {
+            self.error = Some(e);
+            return;
+        }
+
+        let Some(pin) = &self.pin else { return };
+        let hashes = tarball_hashes(&packages);
+        let pinned = match pin.set(&hashes) {
+            Ok(count) => count,
+            Err(e) => {
+                self.error = Some(e);
+                return;
+            }
+        };
+
+        self.busy = Some(label);
+        self.error = None;
+        self.push_activity(format!(
+            "pinned {pinned} lockfile entr{}",
+            if pinned == 1 { "y" } else { "ies" }
+        ));
+
+        let dir = self.consumer_dir.clone();
+        let kind = self.lock.kind;
+        let tx = self.work_tx.clone();
+        std::thread::spawn(move || {
+            let result = lockfile::install(&dir, kind)
+                .map(|()| "install finished".to_string())
+                .map_err(|e| e.to_string());
+            let _ = tx.send(Work::Applied(result));
+        });
+    }
+
+    pub fn repack_selected(&mut self) {
+        if self.busy.is_some() {
+            return;
+        }
+        let Some(item) = self.selected_item() else {
+            return;
+        };
+        if item.source_missing {
+            self.error = Some(format!(
+                "{} was packed from {}, which no longer exists",
+                item.entry.name,
+                item.entry.source_dir.display()
+            ));
+            return;
+        }
+
+        let dir = item.entry.source_dir.clone();
+        self.busy = Some(format!("repacking {}", item.entry.name));
+        let tx = self.work_tx.clone();
+        std::thread::spawn(move || {
+            let _ = tx.send(Work::Repacked(store_view::repack(&dir)));
+        });
+    }
+
+    /// Remove the selected package from the store. Refuses while it is
+    /// hijacked, since the proxy would then have nothing to serve.
+    pub fn evict_selected(&mut self) {
+        let Some(item) = self.selected_item() else {
+            return;
+        };
+        let name = item.entry.name.clone();
+
+        if self.hijacked.contains(&name) {
+            self.error = Some(format!("{name} is hijacked — unsmuggle it first"));
+            return;
+        }
+
+        match store::remove(&name) {
+            Ok(()) => {
+                self.push_activity(format!("evicted {name} from the store"));
+                self.items = store_view::load();
+                self.selected = self.selected.min(self.items.len().saturating_sub(1));
+            }
+            Err(e) => self.error = Some(e),
+        }
+    }
+
+    pub fn on_work(&mut self, work: Work) {
+        self.busy = None;
+        match work {
+            Work::Applied(Ok(line)) => self.push_activity(line),
+            Work::Repacked(Ok(name)) => {
+                self.items = store_view::load();
+                self.push_activity(format!("repacked {name}"));
+                // The tarball changed, so the pin has to follow it.
+                if self.hijacked.contains(&name) {
+                    self.apply(format!("reinstalling {name}"));
+                }
+            }
+            Work::Applied(Err(e)) | Work::Repacked(Err(e)) => self.error = Some(e),
+        }
+    }
+
+    pub fn refresh(&mut self) {
+        self.items = store_view::load();
+        self.report = doctor::run(&self.consumer_dir, self.status.as_ref());
+    }
+
+    /// End the session the way ctrl-c does: unpin, stop interception, and put
+    /// the real packages back.
+    pub fn shutdown(self) {
+        let App {
+            pin,
+            registration,
+            consumer_dir,
+            lock,
+            hijacked,
+            ..
+        } = self;
+
+        drop(pin);
+        drop(registration);
+
+        // Only worth reinstalling if something was actually swapped out.
+        if !hijacked.is_empty() {
+            session::wait_for_interception_to_stop();
+            let _ = lockfile::install(&consumer_dir, lock.kind);
+        }
+    }
+}
+
+/// Wall-clock time for the activity feed. Falls back to UTC when the local
+/// offset cannot be determined, which is possible in a threaded process.
+fn clock() -> String {
+    let now = time::OffsetDateTime::now_local().unwrap_or_else(|_| time::OffsetDateTime::now_utc());
+    format!("{:02}:{:02}:{:02}", now.hour(), now.minute(), now.second())
+}
+
+/// The integrity of what the proxy will serve for each package, which is what
+/// the lockfile has to claim for the fetch to be accepted.
+fn tarball_hashes(names: &[String]) -> std::collections::HashMap<String, String> {
+    names
+        .iter()
+        .filter_map(|name| {
+            let tarball = store::load_tarball(name).ok()?;
+            Some((name.clone(), hijack::integrity_of(&tarball)))
+        })
+        .collect()
+}

--- a/src/tui/doctor.rs
+++ b/src/tui/doctor.rs
@@ -1,0 +1,173 @@
+//! Setup diagnostics.
+//!
+//! Every check answers a question that has actually cost a debugging session:
+//! is the CA there, does the daemon match this binary, is the registry this
+//! project uses actually the one being intercepted.
+
+use std::path::Path;
+
+use crate::net::{ca, control, hosts, launchd, trust};
+use crate::{lockfile, session};
+
+#[derive(PartialEq, Clone, Copy)]
+pub enum Level {
+    Ok,
+    Warn,
+    Bad,
+}
+
+pub struct Check {
+    pub level: Level,
+    pub label: String,
+    pub detail: String,
+}
+
+impl Check {
+    fn new(level: Level, label: &str, detail: impl Into<String>) -> Self {
+        Self {
+            level,
+            label: label.to_string(),
+            detail: detail.into(),
+        }
+    }
+}
+
+pub struct Report {
+    pub machine: Vec<Check>,
+    pub project: Vec<Check>,
+}
+
+impl Report {
+    pub fn worst(&self) -> Level {
+        let mut levels = self.machine.iter().chain(&self.project).map(|c| c.level);
+        if levels.clone().any(|l| l == Level::Bad) {
+            Level::Bad
+        } else if levels.any(|l| l == Level::Warn) {
+            Level::Warn
+        } else {
+            Level::Ok
+        }
+    }
+}
+
+pub fn run(consumer_dir: &Path, daemon: Option<&control::DaemonStatus>) -> Report {
+    Report {
+        machine: machine_checks(daemon),
+        project: project_checks(consumer_dir),
+    }
+}
+
+fn machine_checks(daemon: Option<&control::DaemonStatus>) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    checks.push(if ca::exists() {
+        Check::new(Level::Ok, "local CA", ca::cert_path().display().to_string())
+    } else {
+        Check::new(Level::Bad, "local CA", "missing — run `smuggle setup`")
+    });
+
+    checks.push(if trust::is_in_keychain() {
+        Check::new(Level::Ok, "keychain trust", "trusted as a root")
+    } else {
+        Check::new(
+            Level::Warn,
+            "keychain trust",
+            "not trusted — npm still works, other tools may not",
+        )
+    });
+
+    checks.push(match (trust::is_in_profile(), trust::env_var_active()) {
+        (_, true) => Check::new(Level::Ok, "NODE_EXTRA_CA_CERTS", "active in this shell"),
+        (true, false) => Check::new(
+            Level::Ok,
+            "NODE_EXTRA_CA_CERTS",
+            format!(
+                "in {} — smuggle passes it directly, so this only affects installs you run",
+                trust::profile_path().display()
+            ),
+        ),
+        (false, false) => Check::new(
+            Level::Warn,
+            "NODE_EXTRA_CA_CERTS",
+            "not configured — installs you run yourself will not trust the CA",
+        ),
+    });
+
+    checks.push(match (launchd::is_installed(), launchd::is_loaded()) {
+        (true, true) => Check::new(Level::Ok, "daemon", "installed and running"),
+        (true, false) => Check::new(
+            Level::Bad,
+            "daemon",
+            "installed but not running — run `smuggle setup`",
+        ),
+        (false, _) => Check::new(Level::Bad, "daemon", "not installed — run `smuggle setup`"),
+    });
+
+    checks.push(match daemon {
+        Some(status) if status.version == control::version() => Check::new(
+            Level::Ok,
+            "daemon version",
+            format!("{} (matches this binary)", status.version),
+        ),
+        Some(status) => Check::new(
+            Level::Bad,
+            "daemon version",
+            format!(
+                "{} but this binary is {} — run `smuggle setup`",
+                status.version,
+                control::version()
+            ),
+        ),
+        None => Check::new(Level::Bad, "daemon version", "could not reach the daemon"),
+    });
+
+    checks.push(match hosts::read_block() {
+        None => Check::new(Level::Ok, "redirect", "/etc/hosts clean"),
+        Some(block) if hosts::pid_alive(block.pid) => Check::new(
+            Level::Ok,
+            "redirect",
+            format!("active for {}", block.hosts.join(", ")),
+        ),
+        Some(block) => Check::new(
+            Level::Bad,
+            "redirect",
+            format!(
+                "stale, owned by dead pid {} — run `smuggle cleanup`",
+                block.pid
+            ),
+        ),
+    });
+
+    checks
+}
+
+fn project_checks(consumer_dir: &Path) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    match lockfile::detect(consumer_dir) {
+        Ok(lock) => checks.push(Check::new(
+            Level::Ok,
+            "package manager",
+            format!(
+                "{}",
+                lock.path.file_name().unwrap_or_default().to_string_lossy()
+            ),
+        )),
+        Err(e) => checks.push(Check::new(Level::Bad, "package manager", e)),
+    }
+
+    let registries = session::detect_registries(consumer_dir);
+    if registries.is_empty() {
+        checks.push(Check::new(
+            Level::Warn,
+            "registry",
+            "npm reported none — the public default will be intercepted",
+        ));
+    } else {
+        for registry in &registries {
+            checks.push(Check::new(Level::Ok, "registry", registry.clone()));
+        }
+    }
+
+    checks
+}

--- a/src/tui/doctor.rs
+++ b/src/tui/doctor.rs
@@ -38,6 +38,18 @@ pub struct Report {
 }
 
 impl Report {
+    /// Shown until the first real report arrives. Building one shells out to
+    /// npm, launchctl and security, which is far too slow to do on the event
+    /// loop, so it happens on a worker thread.
+    pub fn pending() -> Self {
+        Self {
+            machine: vec![Check::new(Level::Ok, "checking…", "")],
+            project: Vec::new(),
+        }
+    }
+}
+
+impl Report {
     pub fn worst(&self) -> Level {
         let mut levels = self.machine.iter().chain(&self.project).map(|c| c.level);
         if levels.clone().any(|l| l == Level::Bad) {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -73,10 +73,19 @@ fn event_loop(
             .draw(|frame| view::draw(frame, &app.snapshot()))
             .map_err(|e| format!("draw failed: {e}"))?;
 
+        // Drain everything queued before drawing again. Handling one key per
+        // frame makes held arrow keys crawl, since each repeat then waits for
+        // a full redraw.
         if event::poll(TICK).map_err(|e| format!("input failed: {e}"))? {
-            if let Ok(event::Event::Key(key)) = event::read() {
-                if key.kind == KeyEventKind::Press {
-                    handle_key(app, key.code, key.modifiers);
+            loop {
+                if let Ok(event::Event::Key(key)) = event::read() {
+                    if key.kind == KeyEventKind::Press {
+                        handle_key(app, key.code, key.modifiers);
+                    }
+                }
+                match event::poll(Duration::ZERO) {
+                    Ok(true) => continue,
+                    _ => break,
                 }
             }
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,0 +1,157 @@
+//! The terminal UI.
+//!
+//! `smuggle ui` owns a session: nothing is hijacked until you pick it, and
+//! quitting ends the session the way ctrl-c does, restoring the lockfile and
+//! reinstalling the published packages.
+
+pub mod app;
+pub mod doctor;
+pub mod store_view;
+pub mod theme;
+pub mod view;
+
+use std::path::Path;
+use std::sync::mpsc::{Sender, TryRecvError, channel};
+use std::time::Duration;
+
+use ratatui::crossterm::event::{self, KeyCode, KeyEventKind, KeyModifiers};
+
+use crate::net::control::{Reply, Request, version};
+use crate::{lockfile, session};
+
+use app::{App, View};
+
+/// How often the loop wakes to redraw when nothing has happened. Also the
+/// cadence at which the daemon is asked for its status.
+const TICK: Duration = Duration::from_millis(200);
+const STATUS_EVERY: u32 = 10;
+
+pub fn run(consumer_dir: &Path, extra_registries: &[String]) -> Result<(), String> {
+    // Checked before anything is registered or pinned: initialising a terminal
+    // that is not there panics, and would leave a session behind.
+    if !std::io::IsTerminal::is_terminal(&std::io::stdout()) {
+        return Err(
+            "`smuggle ui` needs an interactive terminal. Use `smuggle` for a plain session.".into(),
+        );
+    }
+
+    let consumer_dir = consumer_dir
+        .canonicalize()
+        .map_err(|e| format!("invalid path: {e}"))?;
+
+    // Fail before taking over the terminal, so the reason stays readable.
+    let lock = lockfile::detect(&consumer_dir)?;
+    let registries = session::resolve_registries_quietly(&consumer_dir, extra_registries);
+
+    // Register with nothing hijacked. The UI decides what to smuggle.
+    let (replies_tx, replies_rx) = channel::<Reply>();
+    let registration = session::start_with_sink(&[], &registries, false, Some(replies_tx.clone()))?;
+    let pin = lockfile::pin(&lock, &Default::default(), false)?;
+
+    let mut app = App::new(consumer_dir, registration, lock, pin);
+    let status_tx = replies_tx;
+
+    let mut terminal =
+        ratatui::try_init().map_err(|e| format!("could not take over the terminal: {e}"))?;
+    let outcome = event_loop(&mut terminal, &mut app, &replies_rx, &status_tx);
+    ratatui::restore();
+
+    app.shutdown();
+    outcome
+}
+
+fn event_loop(
+    terminal: &mut ratatui::DefaultTerminal,
+    app: &mut App,
+    replies: &std::sync::mpsc::Receiver<Reply>,
+    status_tx: &Sender<Reply>,
+) -> Result<(), String> {
+    let mut ticks: u32 = 0;
+
+    loop {
+        terminal
+            .draw(|frame| view::draw(frame, &app.snapshot()))
+            .map_err(|e| format!("draw failed: {e}"))?;
+
+        if event::poll(TICK).map_err(|e| format!("input failed: {e}"))? {
+            if let Ok(event::Event::Key(key)) = event::read() {
+                if key.kind == KeyEventKind::Press {
+                    handle_key(app, key.code, key.modifiers);
+                }
+            }
+        }
+
+        loop {
+            match replies.try_recv() {
+                Ok(reply) => app.on_reply(reply),
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => break,
+            }
+        }
+
+        while let Ok(work) = app.work_rx.try_recv() {
+            app.on_work(work);
+        }
+
+        ticks = ticks.wrapping_add(1);
+        if ticks.is_multiple_of(STATUS_EVERY) {
+            poll_status(status_tx);
+        }
+
+        if app.should_quit {
+            return Ok(());
+        }
+    }
+}
+
+/// Ask the daemon what it is doing on a short-lived connection, and feed the
+/// answer back through the same channel the event stream uses.
+fn poll_status(tx: &Sender<Reply>) {
+    let tx = tx.clone();
+    std::thread::spawn(move || {
+        use std::io::{BufRead, BufReader, Write};
+
+        let Ok(stream) =
+            std::os::unix::net::UnixStream::connect(crate::net::control::socket_path())
+        else {
+            return;
+        };
+        let request =
+            serde_json::to_string(&Request::Status { version: version() }).unwrap_or_default();
+        if writeln!(&stream, "{request}").is_err() {
+            return;
+        }
+
+        let mut line = String::new();
+        if BufReader::new(&stream).read_line(&mut line).is_ok() {
+            if let Ok(reply) = serde_json::from_str::<Reply>(line.trim()) {
+                let _ = tx.send(reply);
+            }
+        }
+    });
+}
+
+fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
+    match code {
+        KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => app.should_quit = true,
+        KeyCode::Char('q') | KeyCode::Esc => app.should_quit = true,
+
+        KeyCode::Tab => {
+            app.view = match app.view {
+                View::Session => View::Store,
+                View::Store => View::Doctor,
+                View::Doctor => View::Session,
+            };
+            app.refresh();
+        }
+
+        KeyCode::Up | KeyCode::Char('k') => app.move_selection(-1),
+        KeyCode::Down | KeyCode::Char('j') => app.move_selection(1),
+
+        KeyCode::Char(' ') if app.view == View::Session => app.toggle_selected(),
+        KeyCode::Char('r') => app.repack_selected(),
+        KeyCode::Char('x') if app.view == View::Store => app.evict_selected(),
+
+        _ => {}
+    }
+}

--- a/src/tui/store_view.rs
+++ b/src/tui/store_view.rs
@@ -1,0 +1,75 @@
+//! The store: everything `smuggle publish` has registered.
+
+use std::path::Path;
+
+use crate::{pack, store};
+
+pub struct StoreItem {
+    pub entry: store::StoreEntry,
+    pub bytes: u64,
+    /// True when the directory the package was packed from is gone, which
+    /// makes the entry unrepackable and almost certainly stale.
+    pub source_missing: bool,
+}
+
+pub fn load() -> Vec<StoreItem> {
+    store::list()
+        .into_iter()
+        .map(|entry| {
+            let bytes = std::fs::metadata(store::tarball_path(&entry.name))
+                .map(|m| m.len())
+                .unwrap_or(0);
+            let source_missing = !entry.source_dir.exists();
+            StoreItem {
+                entry,
+                bytes,
+                source_missing,
+            }
+        })
+        .collect()
+}
+
+/// Re-pack a registered package from its source directory.
+pub fn repack(source_dir: &Path) -> Result<String, String> {
+    let pkg_json_path = source_dir.join("package.json");
+    let raw = std::fs::read_to_string(&pkg_json_path)
+        .map_err(|e| format!("could not read {}: {e}", pkg_json_path.display()))?;
+    let pkg_json: pack::PublishPackageJson =
+        serde_json::from_str(&raw).map_err(|e| format!("could not parse package.json: {e}"))?;
+
+    let name = pkg_json.name.clone().ok_or("package.json has no name")?;
+    let version = pkg_json.version.clone().unwrap_or_else(|| "0.0.0".into());
+
+    let tarball = pack::pack(source_dir, &pkg_json)?;
+    store::save(
+        &name,
+        &version,
+        source_dir,
+        &tarball,
+        &pkg_json.dependencies(),
+    )?;
+
+    Ok(name)
+}
+
+pub fn human_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    match bytes {
+        b if b >= MB => format!("{:.1} MB", b as f64 / MB as f64),
+        b if b >= KB => format!("{} KB", b / KB),
+        b => format!("{b} B"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sizes_read_the_way_people_write_them() {
+        assert_eq!(human_bytes(512), "512 B");
+        assert_eq!(human_bytes(2048), "2 KB");
+        assert_eq!(human_bytes(1024 * 1024 * 3 / 2), "1.5 MB");
+    }
+}

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,0 +1,17 @@
+//! Colours, matching the zinc chrome the teley CLI uses so the two tools look
+//! like they come from the same place.
+
+use ratatui::style::Color;
+
+pub const BG: Color = Color::Rgb(0x09, 0x09, 0x0b);
+pub const PANEL: Color = Color::Rgb(0x18, 0x18, 0x1b);
+pub const BORDER: Color = Color::Rgb(0x27, 0x27, 0x2a);
+pub const BORDER_ACTIVE: Color = Color::Rgb(0x52, 0x52, 0x5b);
+pub const TEXT: Color = Color::Rgb(0xd4, 0xd4, 0xd8);
+pub const TEXT_STRONG: Color = Color::Rgb(0xf4, 0xf4, 0xf5);
+pub const DIM: Color = Color::Rgb(0x71, 0x71, 0x7a);
+pub const ACCENT: Color = Color::Rgb(0x3b, 0x82, 0xf6);
+
+pub const OK: Color = Color::Rgb(0x22, 0xc5, 0x5e);
+pub const WARN: Color = Color::Rgb(0xf5, 0x9e, 0x0b);
+pub const ERROR: Color = Color::Rgb(0xef, 0x44, 0x44);

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -158,7 +158,12 @@ fn draw_session(frame: &mut Frame, area: Rect, app: &Snapshot) {
             Style::default().fg(theme::DIM),
         )));
     }
-    for (i, item) in app.items.iter().enumerate() {
+    // The name takes whatever the version and size columns do not, so a wide
+    // terminal shows full package names instead of truncating to a fixed width.
+    let name_width = (inner.width as usize).saturating_sub(23).max(8);
+
+    let (start, end) = window(app.selected, app.items.len(), inner.height as usize);
+    for (i, item) in app.items.iter().enumerate().take(end).skip(start) {
         let on = app.hijacked.contains(&item.entry.name);
         let selected = i == app.selected;
 
@@ -175,7 +180,11 @@ fn draw_session(frame: &mut Frame, area: Rect, app: &Snapshot) {
                     .bg(row_bg),
             ),
             Span::styled(
-                format!("{:<16}", truncate(&item.entry.name, 16)),
+                format!(
+                    "{:<width$}",
+                    truncate(&item.entry.name, name_width),
+                    width = name_width
+                ),
                 Style::default()
                     .fg(if selected {
                         theme::TEXT_STRONG
@@ -233,7 +242,8 @@ fn draw_store(frame: &mut Frame, area: Rect, app: &Snapshot) {
             Style::default().fg(theme::DIM),
         )));
     }
-    for (i, item) in app.items.iter().enumerate() {
+    let (start, end) = window(app.selected, app.items.len(), inner.height as usize);
+    for (i, item) in app.items.iter().enumerate().take(end).skip(start) {
         let selected = i == app.selected;
         let mut spans = vec![
             Span::styled(
@@ -353,6 +363,18 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, app: &Snapshot) {
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
+/// The slice of a list to draw so the selection stays on screen.
+fn window(selected: usize, len: usize, height: usize) -> (usize, usize) {
+    if height == 0 || len == 0 {
+        return (0, 0);
+    }
+    // Keep the selection in view by scrolling only as far as it needs.
+    let start = selected
+        .saturating_sub(height.saturating_sub(1))
+        .min(len.saturating_sub(height).max(0));
+    (start, (start + height).min(len))
+}
+
 /// Clip to a column width, since a wrapped row would push the panel's bottom
 /// border off a narrow terminal.
 fn truncate(text: &str, width: usize) -> String {
@@ -399,7 +421,11 @@ mod tests {
     }
 
     fn render(snapshot: &Snapshot) -> String {
-        let mut terminal = Terminal::new(TestBackend::new(100, 24)).unwrap();
+        render_at(snapshot, 100, 24)
+    }
+
+    fn render_at(snapshot: &Snapshot, width: u16, height: u16) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
         terminal.draw(|frame| draw(frame, snapshot)).unwrap();
         let buffer = terminal.backend().buffer().clone();
         (0..buffer.area.height)
@@ -469,6 +495,57 @@ mod tests {
         // The empty activity panel has to explain itself, or a session that is
         // doing nothing looks identical to one that is broken.
         assert!(out.contains("pick a package"), "{out}");
+    }
+
+    #[test]
+    fn a_wide_panel_shows_full_package_names() {
+        // The name column takes whatever the other columns leave, so a wide
+        // terminal should not truncate a name that easily fits.
+        let items = vec![item("@sentry/browser-utils", false)];
+        let hijacked = HashSet::new();
+        let report = empty_report();
+        let snapshot = base(&items, &hijacked, &report);
+
+        let wide = render_at(&snapshot, 160, 24);
+        assert!(wide.contains("@sentry/browser-utils"), "{wide}");
+        assert!(wide.contains("2 KB"), "size must survive too:\n{wide}");
+
+        // The same name does not fit a narrow one, and is clipped rather than
+        // pushing the size off the edge.
+        let narrow = render_at(&snapshot, 80, 24);
+        assert!(narrow.contains('…'), "{narrow}");
+        assert!(narrow.contains("2 KB"), "{narrow}");
+    }
+
+    #[test]
+    fn the_window_keeps_the_selection_on_screen() {
+        // Short list: no scrolling.
+        assert_eq!(window(0, 3, 10), (0, 3));
+        // Selection past the bottom scrolls just far enough.
+        assert_eq!(window(12, 40, 10), (3, 13));
+        // Selection near the top does not scroll.
+        assert_eq!(window(2, 40, 10), (0, 10));
+        // Never scrolls past the end.
+        assert_eq!(window(39, 40, 10), (30, 40));
+        assert_eq!(window(0, 0, 10), (0, 0));
+    }
+
+    #[test]
+    fn a_long_list_scrolls_to_the_selection() {
+        let items: Vec<StoreItem> = (0..60)
+            .map(|i| item(&format!("pkg-{i:02}"), false))
+            .collect();
+        let hijacked = HashSet::new();
+        let report = empty_report();
+        let mut snapshot = base(&items, &hijacked, &report);
+        snapshot.selected = 55;
+        let out = render(&snapshot);
+
+        assert!(out.contains("pkg-55"), "selection must be visible:\n{out}");
+        assert!(
+            !out.contains("pkg-00"),
+            "should have scrolled past the top:\n{out}"
+        );
     }
 
     #[test]

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -1,0 +1,543 @@
+//! Rendering.
+//!
+//! Every row is one line and clips rather than wraps: a wrapped row would push
+//! the panels below it off the bottom of a narrow terminal.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use super::app::View;
+use super::doctor::{Level, Report};
+use super::store_view::{StoreItem, human_bytes};
+use super::theme;
+
+/// Everything the UI draws from.
+///
+/// Rendering takes this rather than the app itself, so it depends only on
+/// data. That keeps the live socket and lockfile handles out of the draw path,
+/// and lets a frame be rendered and asserted on without a terminal.
+pub struct Snapshot<'a> {
+    pub consumer_dir: String,
+    pub view: View,
+    pub selected: usize,
+    pub items: &'a [StoreItem],
+    pub hijacked: &'a std::collections::HashSet<String>,
+    pub activity: Vec<String>,
+    pub registries: Option<String>,
+    pub report: &'a Report,
+    pub busy: Option<String>,
+    pub error: Option<String>,
+}
+
+pub fn draw(frame: &mut Frame, app: &Snapshot) {
+    let area = frame.area();
+    frame.render_widget(Block::default().style(Style::default().bg(theme::BG)), area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4),
+            Constraint::Min(3),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    draw_header(frame, chunks[0], app);
+    match app.view {
+        View::Session => draw_session(frame, chunks[1], app),
+        View::Store => draw_store(frame, chunks[1], app),
+        View::Doctor => draw_doctor(frame, chunks[1], app),
+    }
+    draw_status_bar(frame, chunks[2], app);
+}
+
+fn panel(title: &str) -> Block<'_> {
+    panel_styled(title, false)
+}
+
+/// The panel holding the selection gets a brighter border, so it is obvious
+/// which one the arrow keys are driving.
+fn panel_styled(title: &str, focused: bool) -> Block<'_> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(if focused {
+            theme::BORDER_ACTIVE
+        } else {
+            theme::BORDER
+        }))
+        .title(Span::styled(
+            format!(" {title} "),
+            Style::default().fg(theme::DIM),
+        ))
+}
+
+fn draw_header(frame: &mut Frame, area: Rect, app: &Snapshot) {
+    let hijacking = app.hijacked.len();
+    let (dot, dot_style, state) = if hijacking > 0 {
+        (
+            "●",
+            Style::default().fg(theme::OK),
+            format!("hijacking {hijacking}"),
+        )
+    } else {
+        ("○", Style::default().fg(theme::DIM), "idle".to_string())
+    };
+
+    let registries = app
+        .registries
+        .clone()
+        .unwrap_or_else(|| "detecting…".to_string());
+
+    let pinned = if hijacking > 0 {
+        "pinned · restores on quit"
+    } else {
+        "lockfile untouched"
+    };
+
+    // Setup state rides in the header so a broken CA or a stale daemon is
+    // visible from every view, not only the one you have to go looking for.
+    let (setup_mark, setup_colour, setup_text) = match app.report.worst() {
+        Level::Ok => ("✓", theme::OK, "setup ok"),
+        Level::Warn => ("!", theme::WARN, "setup has warnings"),
+        Level::Bad => ("✗", theme::ERROR, "setup needs attention"),
+    };
+
+    let lines = vec![
+        Line::from(vec![
+            Span::styled(format!(" {dot} "), dot_style),
+            Span::styled(
+                state,
+                Style::default()
+                    .fg(theme::TEXT_STRONG)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("   {setup_mark} "),
+                Style::default().fg(setup_colour),
+            ),
+            Span::styled(setup_text, Style::default().fg(theme::DIM)),
+            Span::styled(
+                format!("   smuggle · {}", app.view.title()),
+                Style::default().fg(theme::DIM),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("   project    ", Style::default().fg(theme::DIM)),
+            Span::styled(app.consumer_dir.clone(), Style::default().fg(theme::TEXT)),
+        ]),
+        Line::from(vec![
+            Span::styled("   registries ", Style::default().fg(theme::DIM)),
+            Span::styled(registries, Style::default().fg(theme::TEXT)),
+        ]),
+        Line::from(vec![
+            Span::styled("   lockfile   ", Style::default().fg(theme::DIM)),
+            Span::styled(pinned, Style::default().fg(theme::TEXT)),
+        ]),
+    ];
+
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn draw_session(frame: &mut Frame, area: Rect, app: &Snapshot) {
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(42), Constraint::Percentage(58)])
+        .split(area);
+
+    // Packages
+    let inner = columns[0].inner(ratatui::layout::Margin::new(1, 1));
+    frame.render_widget(panel_styled("Packages", true), columns[0]);
+
+    let mut rows: Vec<Line> = Vec::new();
+    if app.items.is_empty() {
+        rows.push(Line::from(Span::styled(
+            "nothing published yet — run `smuggle publish`",
+            Style::default().fg(theme::DIM),
+        )));
+    }
+    for (i, item) in app.items.iter().enumerate() {
+        let on = app.hijacked.contains(&item.entry.name);
+        let selected = i == app.selected;
+
+        let row_bg = if selected { theme::PANEL } else { theme::BG };
+        rows.push(Line::from(vec![
+            Span::styled(
+                if selected { "▸ " } else { "  " },
+                Style::default().fg(theme::ACCENT).bg(row_bg),
+            ),
+            Span::styled(
+                if on { "● " } else { "○ " },
+                Style::default()
+                    .fg(if on { theme::OK } else { theme::DIM })
+                    .bg(row_bg),
+            ),
+            Span::styled(
+                format!("{:<16}", truncate(&item.entry.name, 16)),
+                Style::default()
+                    .fg(if selected {
+                        theme::TEXT_STRONG
+                    } else {
+                        theme::TEXT
+                    })
+                    .bg(row_bg),
+            ),
+            Span::styled(
+                format!("{:<10} {:>8}", item.entry.version, human_bytes(item.bytes)),
+                Style::default().fg(theme::DIM).bg(row_bg),
+            ),
+        ]));
+    }
+    frame.render_widget(Paragraph::new(rows), inner);
+
+    // Activity
+    let inner = columns[1].inner(ratatui::layout::Margin::new(1, 1));
+    frame.render_widget(panel("Activity"), columns[1]);
+
+    let lines: Vec<Line> = if app.activity.is_empty() {
+        vec![Line::from(Span::styled(
+            if app.hijacked.is_empty() {
+                "pick a package with space to start hijacking it"
+            } else {
+                "no requests yet — run your package manager's install"
+            },
+            Style::default().fg(theme::DIM),
+        ))]
+    } else {
+        app.activity
+            .iter()
+            .take(inner.height as usize)
+            .map(|line| {
+                let colour = if line.starts_with("served") || line.starts_with("rewrote") {
+                    theme::OK
+                } else {
+                    theme::TEXT
+                };
+                Line::from(Span::styled(line.clone(), Style::default().fg(colour)))
+            })
+            .collect()
+    };
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn draw_store(frame: &mut Frame, area: Rect, app: &Snapshot) {
+    let inner = area.inner(ratatui::layout::Margin::new(1, 1));
+    frame.render_widget(panel_styled("Store", true), area);
+
+    let mut rows: Vec<Line> = Vec::new();
+    if app.items.is_empty() {
+        rows.push(Line::from(Span::styled(
+            "nothing published yet — run `smuggle publish` in a package directory",
+            Style::default().fg(theme::DIM),
+        )));
+    }
+    for (i, item) in app.items.iter().enumerate() {
+        let selected = i == app.selected;
+        let mut spans = vec![
+            Span::styled(
+                if selected { "▸ " } else { "  " },
+                Style::default().fg(theme::ACCENT),
+            ),
+            Span::styled(
+                format!("{:<28}", item.entry.name),
+                Style::default().fg(if selected {
+                    theme::TEXT_STRONG
+                } else {
+                    theme::TEXT
+                }),
+            ),
+            Span::styled(
+                format!(
+                    "{:<10} {:>9}  ",
+                    item.entry.version,
+                    human_bytes(item.bytes)
+                ),
+                Style::default().fg(theme::DIM),
+            ),
+            Span::styled(
+                item.entry.source_dir.display().to_string(),
+                Style::default().fg(theme::DIM),
+            ),
+        ];
+        if item.source_missing {
+            spans.push(Span::styled(
+                "  ⚠ source gone",
+                Style::default().fg(theme::WARN),
+            ));
+        }
+        rows.push(Line::from(spans));
+    }
+
+    frame.render_widget(Paragraph::new(rows), inner);
+}
+
+fn draw_doctor(frame: &mut Frame, area: Rect, app: &Snapshot) {
+    let inner = area.inner(ratatui::layout::Margin::new(1, 1));
+    frame.render_widget(panel("Setup"), area);
+
+    let mut rows: Vec<Line> = Vec::new();
+    for check in &app.report.machine {
+        rows.push(check_line(check));
+    }
+    rows.push(Line::from(""));
+    rows.push(Line::from(Span::styled(
+        "This project",
+        Style::default()
+            .fg(theme::TEXT_STRONG)
+            .add_modifier(Modifier::BOLD),
+    )));
+    for check in &app.report.project {
+        rows.push(check_line(check));
+    }
+
+    frame.render_widget(Paragraph::new(rows), inner);
+}
+
+fn check_line(check: &super::doctor::Check) -> Line<'static> {
+    let (mark, colour) = match check.level {
+        Level::Ok => ("✓", theme::OK),
+        Level::Warn => ("!", theme::WARN),
+        Level::Bad => ("✗", theme::ERROR),
+    };
+    Line::from(vec![
+        Span::styled(format!(" {mark} "), Style::default().fg(colour)),
+        Span::styled(
+            format!("{:<22}", check.label),
+            Style::default().fg(theme::TEXT),
+        ),
+        Span::styled(check.detail.clone(), Style::default().fg(theme::DIM)),
+    ])
+}
+
+fn draw_status_bar(frame: &mut Frame, area: Rect, app: &Snapshot) {
+    // Errors and progress replace the key hints, because when either is true
+    // it is the only thing worth reading.
+    if let Some(error) = &app.error {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                format!(" {error}"),
+                Style::default().fg(theme::ERROR),
+            ))),
+            area,
+        );
+        return;
+    }
+    if let Some(busy) = &app.busy {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                format!(" {busy}…"),
+                Style::default().fg(theme::WARN),
+            ))),
+            area,
+        );
+        return;
+    }
+
+    let mut spans = key("↑↓", "select");
+    match app.view {
+        View::Session => {
+            spans.extend(key("space", "smuggle/unsmuggle"));
+            spans.extend(key("r", "repack"));
+        }
+        View::Store => {
+            spans.extend(key("x", "evict"));
+            spans.extend(key("r", "repack"));
+        }
+        View::Doctor => {}
+    }
+    spans.extend(key("tab", "view"));
+    spans.extend(key("q", "quit"));
+
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+/// Clip to a column width, since a wrapped row would push the panel's bottom
+/// border off a narrow terminal.
+fn truncate(text: &str, width: usize) -> String {
+    if text.chars().count() <= width {
+        return text.to_string();
+    }
+    let kept: String = text.chars().take(width.saturating_sub(1)).collect();
+    format!("{kept}…")
+}
+
+fn key(k: &str, label: &str) -> Vec<Span<'static>> {
+    vec![
+        Span::styled(
+            format!(" {k}"),
+            Style::default()
+                .fg(theme::TEXT)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(format!(" {label}   "), Style::default().fg(theme::DIM)),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::StoreEntry;
+    use crate::tui::doctor::Check;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+
+    fn item(name: &str, missing: bool) -> StoreItem {
+        StoreItem {
+            entry: StoreEntry {
+                name: name.into(),
+                version: "1.0.0".into(),
+                source_dir: PathBuf::from("/src/thing"),
+                dependencies: Default::default(),
+            },
+            bytes: 2048,
+            source_missing: missing,
+        }
+    }
+
+    fn render(snapshot: &Snapshot) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(100, 24)).unwrap();
+        terminal.draw(|frame| draw(frame, snapshot)).unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn base<'a>(
+        items: &'a [StoreItem],
+        hijacked: &'a HashSet<String>,
+        report: &'a Report,
+    ) -> Snapshot<'a> {
+        Snapshot {
+            consumer_dir: "/code/app".into(),
+            view: View::Session,
+            selected: 0,
+            items,
+            hijacked,
+            activity: vec![],
+            registries: Some("https://registry.npmjs.org/".into()),
+            report,
+            busy: None,
+            error: None,
+        }
+    }
+
+    fn empty_report() -> Report {
+        Report {
+            machine: vec![Check {
+                level: Level::Ok,
+                label: "local CA".into(),
+                detail: "present".into(),
+            }],
+            project: vec![],
+        }
+    }
+
+    /// Prints a frame so the layout can be eyeballed: `cargo test -- --nocapture frame`
+    #[test]
+    fn frame() {
+        let items = vec![item("@sentry/browser", false), item("villus", false)];
+        let hijacked = HashSet::from(["@sentry/browser".to_string()]);
+        let report = empty_report();
+        let mut snapshot = base(&items, &hijacked, &report);
+        snapshot.activity = vec![
+            "served @sentry/browser from the store (935974 bytes)".into(),
+            "rewrote packument integrity for @sentry/browser".into(),
+        ];
+        println!("{}", render(&snapshot));
+    }
+
+    #[test]
+    fn an_idle_session_says_how_to_start() {
+        let items = vec![item("@scope/pkg", false)];
+        let hijacked = HashSet::new();
+        let report = empty_report();
+        let out = render(&base(&items, &hijacked, &report));
+
+        assert!(out.contains("idle"), "{out}");
+        assert!(out.contains("@scope/pkg"), "{out}");
+        assert!(out.contains("lockfile untouched"), "{out}");
+        // The empty activity panel has to explain itself, or a session that is
+        // doing nothing looks identical to one that is broken.
+        assert!(out.contains("pick a package"), "{out}");
+    }
+
+    #[test]
+    fn package_rows_keep_the_size_visible_in_a_narrow_panel() {
+        // The columns have to fit the packages panel; an overflowing row loses
+        // the size off the right edge.
+        let items = vec![item("@scope/a-fairly-long-package-name", false)];
+        let hijacked = HashSet::new();
+        let report = empty_report();
+        let out = render(&base(&items, &hijacked, &report));
+
+        assert!(out.contains("2 KB"), "size was clipped:\n{out}");
+        assert!(out.contains('…'), "long name should be truncated:\n{out}");
+    }
+
+    #[test]
+    fn a_hijacked_session_reports_the_pin_and_waits_for_an_install() {
+        let items = vec![item("@scope/pkg", false)];
+        let hijacked = HashSet::from(["@scope/pkg".to_string()]);
+        let report = empty_report();
+        let out = render(&base(&items, &hijacked, &report));
+
+        assert!(out.contains("hijacking 1"), "{out}");
+        assert!(out.contains("restores on quit"), "{out}");
+        assert!(out.contains("no requests yet"), "{out}");
+    }
+
+    #[test]
+    fn the_store_view_flags_a_missing_source() {
+        let items = vec![item("gone", true)];
+        let hijacked = HashSet::new();
+        let report = empty_report();
+        let mut snapshot = base(&items, &hijacked, &report);
+        snapshot.view = View::Store;
+        let out = render(&snapshot);
+
+        assert!(out.contains("source gone"), "{out}");
+        assert!(out.contains("evict"), "{out}");
+    }
+
+    #[test]
+    fn a_failing_check_shows_in_the_header_from_any_view() {
+        let items = vec![];
+        let hijacked = HashSet::new();
+        let report = Report {
+            machine: vec![Check {
+                level: Level::Bad,
+                label: "daemon".into(),
+                detail: "not installed".into(),
+            }],
+            project: vec![],
+        };
+        let out = render(&base(&items, &hijacked, &report));
+        assert!(out.contains("setup needs attention"), "{out}");
+    }
+
+    #[test]
+    fn an_error_replaces_the_key_hints() {
+        let items = vec![];
+        let hijacked = HashSet::new();
+        let report = empty_report();
+        let mut snapshot = base(&items, &hijacked, &report);
+        snapshot.error = Some("something broke".into());
+        let out = render(&snapshot);
+
+        assert!(out.contains("something broke"), "{out}");
+        assert!(
+            !out.contains("quit"),
+            "hints should give way to the error:\n{out}"
+        );
+    }
+}


### PR DESCRIPTION
Adds `smuggle ui`, a terminal UI that owns a session.

It starts with nothing hijacked and you pick packages from the list. Space smuggles or unsmuggles one, which re-registers with the daemon, re-pins the lockfile and reinstalls off the event loop. Quitting ends the session exactly as ctrl-c does, restoring the lockfile and putting the real packages back.

Three views: the session shows what is hijacked plus a live activity feed, the store lets you evict and repack published packages and flags any whose source directory is gone, and the doctor checks the CA, keychain, daemon, redirect and this project's registry. The doctor's worst result sits in the header, so a stale daemon or an unintercepted registry is visible from anywhere rather than only when you go looking.

Rendering takes a snapshot of plain data rather than the app itself, which keeps the socket and lockfile handles out of the draw path and lets frames be rendered and asserted on in tests without a terminal.
